### PR TITLE
Add bindings subpackage to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setuptools.setup(
         "test": ["tox", "pytest", "pytest-cov", "coverage", "flake8",
                  "flake8-docstrings", "asynctest"],
     },
-    packages=[__name__],
+    packages=["swift_x_account_sharing", "swift_x_account_sharing.bindings"],
     platforms="any",
     entry_points={
         "console_scripts": [


### PR DESCRIPTION
### Changes
- Hofix to add bindings subpackage to setup.py to enable pip install with bindings.
