### PR TITLE
Remove gunicorn lock

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 aiohttp
 uvloop
 asyncpg
-gunicorn==19.9.0
+gunicorn>=20.0.1


### PR DESCRIPTION
### Description

Gunicorn is no longer required to be version locked since issues with the musl-libc builds were fixed, and the newest version works.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### Changes Made

* Remove gunicorn 19.9.0 version lock from requirements.txt

### Testing

- [x] Tests do not apply

