### PR TITLE
Feature/add bulk unshare

### DIFF
--- a/bindings/js/swift_x_account_sharing_bind.js
+++ b/bindings/js/swift_x_account_sharing_bind.js
@@ -200,26 +200,52 @@ class SwiftXAccountSharing {
     let url = new URL(
       "/share/".concat(username, "/", container), this.address
     );
-    url.searchParams.append("user", this._parseListString(userlist));
-    url.searchParams.append("valid", signed.valid_until);
-    url.searchParams.append("signature", signed.signature);
 
     let signed = await this._getSignature(
       60,
       "/share/".concat(username, "/", container)
     );
 
+    url.searchParams.append("user", this._parseListString(userlist));
+    url.searchParams.append("valid", signed.valid_until);
+    url.searchParams.append("signature", signed.signature);
+
     let deleted = fetch(
       url, {method: "DELETE"}
     ).then(
       (resp) => {
-        if (resp.status == 204) {return true;}
-        if (resp.status == 404) {return false;}
+        return resp.status == 204 ? true : false;
       }
     );
     return deleted;
-  }    
+  }
+  
+  async shareContainerDeleteAccess(
+    username,
+    container
+  ) {
+    // Delete all shares on a container
+    let url = new URL(
+      "/share/".concat(username, "/", container), this.address
+    );
+
+    let signed = await this._getSignature(
+      60,
+      "/share/".concat(username, "/", container)
+    )
+
+    url.searchParams.append("valid", signed.valid_until);
+    url.searchParams.append("signature", signed.signature);
+
+    let deleted = fetch(
+      url, {method: "DELETE"}
+    ).then(
+      (resp) => {
+        return resp.status == 204 ? true : false;
+      }
+    );
+    return deleted;
+  }
 }
 
 export default SwiftXAccountSharing;
-  

--- a/swift_x_account_sharing/api.py
+++ b/swift_x_account_sharing/api.py
@@ -194,6 +194,35 @@ async def delete_share_handler(
         )
     except InterfaceError:
         handle_dropped_connection(request)
+    except KeyError:
+        # If can't find user from query, the client wants a bulk unshare
+        return await delete_container_shares_handler(
+            request.match_info["owner"],
+            request.match_info["container"]
+        )
+
+    MODULE_LOGGER.log(
+        logging.DEBUG,
+        "Deleted following shares: %s", str(deleted)
+    )
+
+    return aiohttp.web.Response(
+        status=204,
+        body="OK"
+    )
+
+
+async def delete_container_shares_handler(
+        request: aiohttp.web.Request
+) -> aiohttp.web.Response:
+    """Delete all shares from a container."""
+    try:
+        deleted = await request.app["db_conn"].delete_container_shares(
+            request.match_info["owner"],
+            request.match_info["container"]
+        )
+    except InterfaceError:
+        handle_dropped_connection(request)
 
     MODULE_LOGGER.log(
         logging.DEBUG,

--- a/swift_x_account_sharing/api.py
+++ b/swift_x_account_sharing/api.py
@@ -11,7 +11,9 @@ from asyncpg import InterfaceError
 MODULE_LOGGER = logging.getLogger("api")
 
 
-def handle_dropped_connection(request):
+def handle_dropped_connection(
+        request: aiohttp.web.Request
+):
     """Handle dropped database connection."""
     MODULE_LOGGER.log(
         logging.ERROR,
@@ -26,7 +28,9 @@ def handle_dropped_connection(request):
     )
 
 
-async def has_access_handler(request):
+async def has_access_handler(
+        request: aiohttp.web.Request
+) -> aiohttp.web.Response:
     """Handle has-access endpoint query."""
     # Future authorization check here
 
@@ -47,7 +51,9 @@ async def has_access_handler(request):
     return aiohttp.web.json_response(access_list)
 
 
-async def access_details_handler(request):
+async def access_details_handler(
+        request: aiohttp.web.Request
+) -> aiohttp.web.Response:
     """Handle access-details endpoint query."""
     # Future authorization check here
 
@@ -70,7 +76,9 @@ async def access_details_handler(request):
     return aiohttp.web.json_response(access_details)
 
 
-async def gave_access_handler(request):
+async def gave_access_handler(
+        request: aiohttp.web.Request
+) -> aiohttp.web.Response:
     """Handle gave-access endpoint query."""
     # Future authorization check here
 
@@ -92,7 +100,9 @@ async def gave_access_handler(request):
     return aiohttp.web.json_response(shared_list)
 
 
-async def shared_details_handler(request):
+async def shared_details_handler(
+        request: aiohttp.web.Request
+) -> aiohttp.web.Response:
     """Handle shared-details endpoint query."""
     # Future authorization check here
 
@@ -115,7 +125,9 @@ async def shared_details_handler(request):
     return aiohttp.web.json_response(shared_details)
 
 
-async def share_container_handler(request):
+async def share_container_handler(
+        request: aiohttp.web.Request
+) -> aiohttp.web.Response:
     """Handle share-container endpoint query."""
     # Future authorization check here
 
@@ -140,7 +152,9 @@ async def share_container_handler(request):
     return aiohttp.web.json_response(shared)
 
 
-async def edit_share_handler(request):
+async def edit_share_handler(
+        request: aiohttp.web.Request
+) -> aiohttp.web.Response:
     """Handle container shared rights editions."""
     # Future authorization check here
 
@@ -164,7 +178,9 @@ async def edit_share_handler(request):
     return aiohttp.web.json_response(edited)
 
 
-async def delete_share_handler(request):
+async def delete_share_handler(
+        request: aiohttp.web.Response
+) -> aiohttp.web.Request:
     """Handle unshare-container endpoint query."""
     # Future authorization check here
 

--- a/swift_x_account_sharing/api.py
+++ b/swift_x_account_sharing/api.py
@@ -169,8 +169,7 @@ async def delete_share_handler(
     except KeyError:
         # If can't find user from query, the client wants a bulk unshare
         return await delete_container_shares_handler(
-            request.match_info["owner"],
-            request.match_info["container"]
+            request
         )
 
     MODULE_LOGGER.log(

--- a/swift_x_account_sharing/api.py
+++ b/swift_x_account_sharing/api.py
@@ -32,10 +32,6 @@ async def has_access_handler(
         request: aiohttp.web.Request
 ) -> aiohttp.web.Response:
     """Handle has-access endpoint query."""
-    # Future authorization check here
-
-    # Check for incorrect client query here
-
     try:
         access_list = await request.app["db_conn"].get_access_list(
             request.match_info["user"]
@@ -55,10 +51,6 @@ async def access_details_handler(
         request: aiohttp.web.Request
 ) -> aiohttp.web.Response:
     """Handle access-details endpoint query."""
-    # Future authorization check here
-
-    # Check for incorrect client query here
-
     try:
         access_details = \
             await request.app["db_conn"].get_access_container_details(
@@ -80,10 +72,6 @@ async def gave_access_handler(
         request: aiohttp.web.Request
 ) -> aiohttp.web.Response:
     """Handle gave-access endpoint query."""
-    # Future authorization check here
-
-    # Check for incorrect client query here
-
     try:
         shared_list = await request.app["db_conn"].get_shared_list(
             request.match_info["owner"]
@@ -104,10 +92,6 @@ async def shared_details_handler(
         request: aiohttp.web.Request
 ) -> aiohttp.web.Response:
     """Handle shared-details endpoint query."""
-    # Future authorization check here
-
-    # Check for incorrect client query here
-
     try:
         shared_details = \
             await request.app["db_conn"].get_shared_container_details(
@@ -129,10 +113,6 @@ async def share_container_handler(
         request: aiohttp.web.Request
 ) -> aiohttp.web.Response:
     """Handle share-container endpoint query."""
-    # Future authorization check here
-
-    # Check for incorrect client query here
-
     try:
         shared = await request.app["db_conn"].add_share(
             request.match_info["owner"],
@@ -156,10 +136,6 @@ async def edit_share_handler(
         request: aiohttp.web.Request
 ) -> aiohttp.web.Response:
     """Handle container shared rights editions."""
-    # Future authorization check here
-
-    # Check for incorrect client query here
-
     try:
         edited = await request.app["db_conn"].edit_share(
             request.match_info["owner"],
@@ -182,10 +158,6 @@ async def delete_share_handler(
         request: aiohttp.web.Response
 ) -> aiohttp.web.Request:
     """Handle unshare-container endpoint query."""
-    # Future authorization check here
-
-    # Check for incorrect client query here
-
     try:
         deleted = await request.app["db_conn"].delete_share(
             request.match_info["owner"],

--- a/swift_x_account_sharing/db.py
+++ b/swift_x_account_sharing/db.py
@@ -154,6 +154,26 @@ class DBConn:
                 )
         return True
 
+    async def delete_container_shares(
+        self,
+        owner: str,
+        container: str
+    ) -> bool:
+        """Delete all shares for a container in the database."""
+        async with self.conn.transaction():
+            await self.conn.execute(
+                """
+                DELETE FROM Shares
+                WHERE
+                    container = $1 AND
+                    container_owner = $2
+                ;
+                """,
+                container,
+                owner
+            )
+        return True
+
     async def get_access_list(
             self,
             user: str

--- a/swift_x_account_sharing/db.py
+++ b/swift_x_account_sharing/db.py
@@ -5,6 +5,7 @@ import os
 import logging
 import asyncio
 import random
+import typing
 
 import asyncpg
 
@@ -65,7 +66,14 @@ class DBConn:
         if self.conn is not None:
             await self.conn.close()
 
-    async def add_share(self, owner, container, userlist, access, address):
+    async def add_share(
+            self,
+            owner: str,
+            container: str,
+            userlist: typing.List[str],
+            access: typing.List[str],
+            address: str
+    ) -> bool:
         """Add a share action to the database."""
         async with self.conn.transaction():
             for key in userlist:
@@ -92,7 +100,13 @@ class DBConn:
                 )
         return True
 
-    async def edit_share(self, owner, container, userlist, access):
+    async def edit_share(
+            self,
+            owner: str,
+            container: str,
+            userlist: typing.List[str],
+            access: typing.List[str]
+    ) -> bool:
         """Edit a share action in the database."""
         async with self.conn.transaction():
             for key in userlist:
@@ -116,7 +130,12 @@ class DBConn:
                 )
         return True
 
-    async def delete_share(self, owner, container, userlist):
+    async def delete_share(
+            self,
+            owner: str,
+            container: str,
+            userlist: typing.List[str]
+    ) -> bool:
         """Delete a share action from the database."""
         async with self.conn.transaction():
             for key in userlist:
@@ -135,7 +154,10 @@ class DBConn:
                 )
         return True
 
-    async def get_access_list(self, user):
+    async def get_access_list(
+            self,
+            user: str
+    ) -> typing.List[dict]:
         """Get the containers shared to the specified user."""
         query = await self.conn.fetch(
             """
@@ -155,7 +177,10 @@ class DBConn:
             for i in query
         ]
 
-    async def get_shared_list(self, user):
+    async def get_shared_list(
+            self,
+            user: str
+    ) -> typing.List[str]:
         """Get the containers that the user has shared."""
         query = await self.conn.fetch(
             """
@@ -169,7 +194,12 @@ class DBConn:
 
         return [i["container"] for i in query]
 
-    async def get_access_container_details(self, user, owner, container):
+    async def get_access_container_details(
+            self,
+            user: str,
+            owner: str,
+            container: str
+    ) -> dict:
         """Get shared container details for share receiver."""
         query = await self.conn.fetchrow(
             """
@@ -207,7 +237,11 @@ class DBConn:
             "access": access,
         }
 
-    async def get_shared_container_details(self, owner, container):
+    async def get_shared_container_details(
+            self,
+            owner: str,
+            container: str
+    ) -> typing.List[dict]:
         """Get shared container details for sharer."""
         query = await self.conn.fetch(
             """

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -21,7 +21,8 @@ from swift_x_account_sharing.api import (
     shared_details_handler,
     share_container_handler,
     edit_share_handler,
-    delete_share_handler
+    delete_share_handler,
+    delete_container_shares_handler,
 )
 
 
@@ -36,6 +37,7 @@ class APITestClass(asynctest.TestCase):
                     "add_share": asynctest.CoroutineMock(),
                     "edit_share": asynctest.CoroutineMock(),
                     "delete_share": asynctest.CoroutineMock(),
+                    "delete_container_shares": asynctest.CoroutineMock(),
                     "get_access_list": asynctest.CoroutineMock(),
                     "get_shared_list": asynctest.CoroutineMock(),
                     "get_access_container_details": asynctest.CoroutineMock(),
@@ -127,6 +129,12 @@ class APITestClass(asynctest.TestCase):
             resp = await delete_share_handler(self.mock_request)
             self.assertEqual(resp.status, 204)
 
+    async def test_endpoint_delete_container_shares_correct(self):
+        """Test the delete_container_shares endpoint for conformity."""
+        with self.patch_json_dump:
+            resp = await delete_container_shares_handler(self.mock_request)
+            self.assertEqual(resp.status, 204)
+
 
 class APILostDatabaseConnectionClass(asynctest.TestCase):
     """Test the sharing backend API upon database failure."""
@@ -158,6 +166,9 @@ class APILostDatabaseConnectionClass(asynctest.TestCase):
                         "delete_share": asynctest.mock.Mock(
                             side_effect=InterfaceError('Lost connection')
                         ),
+                        "delete_container_shares": asynctest.mock.Mock(
+                            side_effect=InterfaceError('Lost connection')
+                        ),
                     })
             },
             "query": {
@@ -185,50 +196,57 @@ class APILostDatabaseConnectionClass(asynctest.TestCase):
         )
 
     async def test_endpoint_has_access_interface_error(self):
-        """Test the has-access endpoint for dropped connection."""
+        """Test the has_access endpoint for dropped connection."""
         with self.patch_handle_dropped_connection:
             with self.assertRaises(aiohttp.web.HTTPServiceUnavailable):
                 await has_access_handler(self.mock_request)
         self.handle_dropped_connection_mock.assert_called_once()
 
     async def test_endpoint_access_details_interface_error(self):
-        """Test the access-details endpoint for dropped connection."""
+        """Test the access_details endpoint for dropped connection."""
         with self.patch_handle_dropped_connection:
             with self.assertRaises(aiohttp.web.HTTPServiceUnavailable):
                 await access_details_handler(self.mock_request)
         self.handle_dropped_connection_mock.assert_called_once()
 
     async def test_endpoint_gave_access_interface_error(self):
-        """Test the gave-access endpoint for dropped connection."""
+        """Test the gave_access endpoint for dropped connection."""
         with self.patch_handle_dropped_connection:
             with self.assertRaises(aiohttp.web.HTTPServiceUnavailable):
                 await gave_access_handler(self.mock_request)
         self.handle_dropped_connection_mock.assert_called_once()
 
     async def test_endpoint_shared_details_interface_error(self):
-        """Test the shared-details endpoint for dropped connection."""
+        """Test the shared_details endpoint for dropped connection."""
         with self.patch_handle_dropped_connection:
             with self.assertRaises(aiohttp.web.HTTPServiceUnavailable):
                 await shared_details_handler(self.mock_request)
         self.handle_dropped_connection_mock.assert_called_once()
 
     async def test_endpoint_add_share_interface_error(self):
-        """Test the add-share endpoint for dropped connection."""
+        """Test the add_share endpoint for dropped connection."""
         with self.patch_handle_dropped_connection:
             with self.assertRaises(aiohttp.web.HTTPServiceUnavailable):
                 await share_container_handler(self.mock_request)
         self.handle_dropped_connection_mock.assert_called_once()
 
     async def test_endpoint_edit_share_interface_error(self):
-        """Test the add-share endpoint for dropped connection."""
+        """Test the edit_share endpoint for dropped connection."""
         with self.patch_handle_dropped_connection:
             with self.assertRaises(aiohttp.web.HTTPServiceUnavailable):
                 await edit_share_handler(self.mock_request)
         self.handle_dropped_connection_mock.assert_called_once()
 
     async def test_endpoint_delete_share_interface_error(self):
-        """Test the add-share endpoint for dropped connection."""
+        """Test the delete_share endpoint for dropped connection."""
         with self.patch_handle_dropped_connection:
             with self.assertRaises(aiohttp.web.HTTPServiceUnavailable):
                 await delete_share_handler(self.mock_request)
+        self.handle_dropped_connection_mock.assert_called_once()
+
+    async def test_endpoint_delete_container_shares_interface_error(self):
+        """Test the delete_container_shares endpoint for dropped conn."""
+        with self.patch_handle_dropped_connection:
+            with self.assertRaises(aiohttp.web.HTTPServiceUnavailable):
+                await delete_container_shares_handler(self.mock_request)
         self.handle_dropped_connection_mock.assert_called_once()

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -184,6 +184,14 @@ class DBMethodTestCase(asynctest.TestCase):
         )
         self.db.conn.execute.assert_awaited()
 
+    async def test_delete_container_shares(self):
+        """Test delete_container_shares method."""
+        await self.db.delete_container_shares(
+            "test-owner",
+            "test-container"
+        )
+        self.db.conn.execute.assert_awaited()
+
     async def test_get_access_list(self):
         """Test get_access_list method."""
         await self.db.get_access_list(


### PR DESCRIPTION
### Description

Deleting container share actions in bulk was required for UI functionality.

### Related issues
<!-- Reference any follow up issues with "Fixes #<issue-num>." -->

### Type of change

<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update (this needs a follow up PR)

### Changes Made

* Add container bulk unshare API endpoint
* Add `api.py` type hints
* Add `db.py` type hints
* Remove incorrect to-do comments from `api.py`, as the functionality flagged is implemented elsewhere.

### Testing

<!-- Are any tests part of this PR. -->
<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] Unit Tests
- [ ] Integration Tests
- [ ] Tests do not apply
- [ ] Needs testing (start an issue or do a follow up PR about it)

### Mentions
<!-- Shout outs to your friends that you made this happen or need help. -->
