### PR TITLE
Fix incorrect HTTP status code on database uniqueness errors

### DIFF
--- a/swift_x_account_sharing/middleware.py
+++ b/swift_x_account_sharing/middleware.py
@@ -49,6 +49,6 @@ async def catch_uniqueness_error(
     try:
         return await handler(request)
     except UniqueViolationError:
-        raise aiohttp.web.HTTPClientError(
+        raise aiohttp.web.HTTPConflict(
             reason="Duplicate entries are not allowed."
         )

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -58,7 +58,7 @@ class MiddlewareTestCase(asynctest.TestCase):
         unique_violating_handler = asynctest.CoroutineMock(
             side_effect=UniqueViolationError
         )
-        with self.assertRaises(aiohttp.web.HTTPClientError):
+        with self.assertRaises(aiohttp.web.HTTPConflict):
             await catch_uniqueness_error(
                 self.mock_request,
                 unique_violating_handler


### PR DESCRIPTION
### Description

Database uniqueness errors should generate a descriptive and correct error, which has now been implemented.

### Related issues
<!-- Reference any follow up issues with "Fixes #<issue-num>." -->

### Type of change

<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update (this needs a follow up PR)

### Changes Made

* Replace `aiohttp.web.HTTPClientError` with `aiohttp.web.HTTPConflict` (HTTP409)

### Testing

<!-- Are any tests part of this PR. -->
<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] Unit Tests
- [ ] Integration Tests
- [ ] Tests do not apply
- [ ] Needs testing (start an issue or do a follow up PR about it)

### Mentions
<!-- Shout outs to your friends that you made this happen or need help. -->
