### PR TITLE
Fix convert datetime to string

### DIFF
--- a/swift_x_account_sharing/db.py
+++ b/swift_x_account_sharing/db.py
@@ -214,7 +214,7 @@ class DBConn:
             {
                 "container": i["container"],
                 "owner": i["container_owner"],
-                "sharingdate": i["sharingdate"]
+                "sharingdate": i["sharingdate"].strftime("%d %b %Y")
             }
             for i in query
         ]

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -11,6 +11,7 @@ import aiohttp.web
 
 from swift_x_account_sharing.db import DBConn
 from swift_x_account_sharing.db import handle_dropped_connection
+import datetime
 
 
 class HandleDroppedTestClass(asynctest.TestCase):
@@ -157,14 +158,14 @@ class DBMethodTestCase(asynctest.TestCase):
         self.connection_transaction_mock = asynctest.MagicMock(
             asyncpg.Connection.transaction
         )
-
+        mock_date = datetime.datetime(2020, 7, 15, 12, 25, 26, 791901)
         self.asyncpg_connection_mock = SimpleNamespace(**{
             "fetch": asynctest.CoroutineMock(
                 return_value=[{
                     "container": "test-container",
                     "container_owner": "test-owner",
                     "recipient": "test-receiver",
-                    "sharingdate": "testdate",
+                    "sharingdate": mock_date,
                     "address": "test-address",
                     "r_read": True,
                     "r_write": True,
@@ -175,7 +176,7 @@ class DBMethodTestCase(asynctest.TestCase):
                     "r_read": True,
                     "r_write": True,
                     "container": "test-container",
-                    "sharingdate": "testdate",
+                    "sharingdate": "15 July 2020",
                     "container_owner": "test-owner",
                     "recipient": "test-recipient",
                     "address": "test-address",


### PR DESCRIPTION

### Description

<!-- Please include a summary of the change or any information deemed important. -->

caused an error in the viewing of shared containers to a project because the return from the database was datetime but the conversion cause an error and could not process shared containers.

Actual error:
```
DEBUG:api:Returning following access list: [{'container': .....................', 'owner': '.....', 'sharingdate': datetime.datetime(2020, 7, 16, 12, 46, 2, 486203)}]
[2020-07-16 13:49:12 +0000] [10] [ERROR] Error handling request
Traceback (most recent call last):
  File "/usr/local/lib/python3.7/site-packages/aiohttp/web_protocol.py", line 418, in start
    resp = await task
  File "/usr/local/lib/python3.7/site-packages/aiohttp/web_app.py", line 458, in _handle
    resp = await handler(request)
  File "/usr/local/lib/python3.7/site-packages/aiohttp/web_middlewares.py", line 119, in impl
    return await handler(request)
  File "/usr/local/lib/python3.7/site-packages/swift_x_account_sharing/middleware.py", line 28, in add_cors
    resp = await handler(request)
  File "/usr/local/lib/python3.7/site-packages/swift_x_account_sharing/middleware.py", line 50, in check_db_conn
    return await handler(request)
  File "/usr/local/lib/python3.7/site-packages/swift_x_account_sharing/auth.py", line 124, in handle_validate_authentication
    return await handler(request)
  File "/usr/local/lib/python3.7/site-packages/swift_x_account_sharing/middleware.py", line 60, in catch_uniqueness_error
    return await handler(request)
  File "/usr/local/lib/python3.7/site-packages/swift_x_account_sharing/api.py", line 31, in has_access_handler
    return aiohttp.web.json_response(access_list)
  File "/usr/local/lib/python3.7/site-packages/aiohttp/web_response.py", line 715, in json_response
    text = dumps(data)
  File "/usr/local/lib/python3.7/json/__init__.py", line 231, in dumps
    return _default_encoder.encode(obj)
  File "/usr/local/lib/python3.7/json/encoder.py", line 199, in encode
    chunks = self.iterencode(o, _one_shot=True)
  File "/usr/local/lib/python3.7/json/encoder.py", line 257, in iterencode
    return _iterencode(o, 0)
  File "/usr/local/lib/python3.7/json/encoder.py", line 179, in default
    raise TypeError(f'Object of type {o.__class__.__name__} '
TypeError: Object of type datetime is not JSON serializable
```

### Related issues
<!-- Reference any follow up issues with "Fixes #<issue-num>." -->

### Type of change

<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)


### Changes Made

<!-- List changes made. -->
1. process the `sharingdate` as day, month, year
2. update tests

### Testing

<!-- Are any tests part of this PR. -->
<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] Unit Tests

### Mentions
<!-- Shout outs to your friends that you made this happen or need help. -->
tested in staging.
