### PR TITLE
update docker image with rust in build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8-alpine3.12 as BACKEND
+FROM python:3.8-alpine3.13 as BACKEND
 
 RUN apk add --update \
     && apk add --no-cache build-base curl-dev linux-headers bash git\
@@ -9,11 +9,14 @@ COPY requirements.txt /root/swift_sharing/requirements.txt
 COPY setup.py /root/swift_sharing/setup.py
 COPY swift_x_account_sharing /root/swift_sharing/swift_x_account_sharing
 
+RUN apk add --no-cache rust cargo \
+    && rm -rf /var/cache/apk/*
+
 RUN pip install --upgrade pip\
     && pip install -r /root/swift_sharing/requirements.txt \
     && pip install /root/swift_sharing
 
-FROM python:3.8-alpine3.12
+FROM python:3.8-alpine3.13
 
 RUN apk add --no-cache --update bash
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,13 @@
 FROM python:3.8-alpine3.13 as BACKEND
 
 RUN apk add --update \
-    && apk add --no-cache build-base curl-dev linux-headers bash git\
-    && apk add --no-cache libressl-dev libffi-dev\
+    && apk add --no-cache build-base curl-dev linux-headers bash git \
+    && apk add --no-cache libressl-dev libffi-dev rust cargo \
     && rm -rf /var/cache/apk/*
 
 COPY requirements.txt /root/swift_sharing/requirements.txt
 COPY setup.py /root/swift_sharing/setup.py
 COPY swift_x_account_sharing /root/swift_sharing/swift_x_account_sharing
-
-RUN apk add --no-cache rust cargo \
-    && rm -rf /var/cache/apk/*
 
 RUN pip install --upgrade pip\
     && pip install -r /root/swift_sharing/requirements.txt \

--- a/swift_x_account_sharing/__init__.py
+++ b/swift_x_account_sharing/__init__.py
@@ -2,6 +2,6 @@
 
 
 __name__ = "swift_x_account_sharing"
-__version__ = "0.5.10"
+__version__ = "0.5.11"
 __author__ = "CSC Developers"
 __license__ = "MIT License"


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change or any information deemed important. -->

update docker image with rust in build, needed by `cryptography` package https://cryptography.io/en/latest/installation.html#rust
bump version to 0.5.11